### PR TITLE
Fix PD multiple components bug

### DIFF
--- a/khoca.py
+++ b/khoca.py
@@ -46,10 +46,19 @@ NUM_THREADS = 1 if debugging else 12
 def pd_to_mypd(pd):
     result = list()
     for i in pd:
-        if (i[3] == ((i[1] + 1) % (2 * len(pd)))):
-            result.append([2,i[0] - 1,i[1] - 1,i[2] - 1,i[3] - 1])
+        # If they are consecutive, we orient them ascending.
+        if abs(i[3] - i[1]) == 1:
+            if i[3] == i[1] + 1:
+                result.append([2,i[0] - 1,i[1] - 1,i[2] - 1,i[3] - 1])
+            else:
+                result.append([3,i[1] - 1,i[2] - 1,i[3] - 1,i[0] - 1])
+        # Now we have to assume that they form the looping end of a component in a link diagram.
+        # Which means they should be oriented descending.
         else:
-            result.append([3,i[1] - 1,i[2] - 1,i[3] - 1,i[0] - 1])
+            if i[3] < i[1]:
+                result.append([2,i[0] - 1,i[1] - 1,i[2] - 1,i[3] - 1])
+            else:
+                result.append([3,i[1] - 1,i[2] - 1,i[3] - 1,i[0] - 1])
     return result
 
 def generate_binary_tree(length, s = 0):


### PR DESCRIPTION
There is a bug, when a PD component loops back on itself.
In this case, the numbers `b` and `d` in the crossing `[a, b, c, d]` are **not** one apart.
Therefore the `if` in:
https://github.com/LLewark/khoca/blob/dbb4a8068f8d4c208f7c5598add1b3d38f1a0919/khoca.py#L48-L52
is not sufficient to catch this case for multiple components, since in this case `2 * len(pd)` is **not the size of the component**.

If we knew the size of the component, we could mod by that after shifting the indices to `0`, but I think the simpler solution is to do as I suggest in this pull-request.